### PR TITLE
add latex and mermaid support to output

### DIFF
--- a/notes/_build/_build.py
+++ b/notes/_build/_build.py
@@ -72,6 +72,14 @@ def convert_md_to_html(src, pathSource, pathTemplate, pathOutput):
     
     mdString = ''.join(md)
 
+    # add scirpts for latex and mermaid if required
+    if 'latex: true' in mdString.lower():
+        scriptText = '<!-- Script: Latex (Included) --> <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script> <script> MathJax = { tex: { inlineMath: [[\'$\', \'$\'], [\'\\\\(\', \'\\\\)\']]} }; </script> <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"> </script>'
+        template[template.index('<!-- Script: Latex -->')] = scriptText
+    if 'mermaid: true' in mdString.lower():
+        scriptText = '<!-- Script: Mermaid (Included) --> <script type="module" defer> import mermaid from \'https://cdn.jsdelivr.net/npm/mermaid@9/dist/mermaid.esm.min.mjs\'; mermaid. Initialize({ securityLevel: \'loose\', startOnLoad: true }); let observer = new MutationObserver(mutations => { for(let mutation of mutations) { mutation.target.style.visibility = "visible"; } }); document.querySelectorAll("pre.mermaid-pre div.mermaid").forEach(item => { observer.observe(item, {  attributes: true,  attributeFilter: [\'data-processed\'] }); }); </script>'
+        template[template.index('<!-- Script: Mermaid -->')] = scriptText
+
 
     # style Obsidian links
     ## TODO

--- a/notes/_build/_template.html
+++ b/notes/_build/_template.html
@@ -52,6 +52,8 @@ O clemens, O pia, O dulcis Virgo Maria. -->
 	</div>
 
 <!-- Scripts -->
+<!-- Script: Latex -->
+<!-- Script: Mermaid -->
 <script src="../assets/js/jquery.min.js"></script>
 <script type="text/javascript" src="../assets/js/bigfoot.js"></script>
 <script type="text/javascript">

--- a/reading-notes/_build/_build.py
+++ b/reading-notes/_build/_build.py
@@ -39,6 +39,13 @@ def convert_md_to_html(pathSource, pathTemplate, pathOutput):
     
     mdString = ''.join(md)
 
+    # add scirpts for latex and mermaid if required
+    if 'latex: true' in mdString.lower():
+        scriptText = '<!-- Script: Latex (Included) --> <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script> <script> MathJax = { tex: { inlineMath: [[\'$\', \'$\'], [\'\\\\(\', \'\\\\)\']]} }; </script> <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"> </script>'
+        template[template.index('<!-- Script: Latex -->')] = scriptText
+    if 'mermaid: true' in mdString.lower():
+        scriptText = '<!-- Script: Mermaid (Included) --> <script type="module" defer> import mermaid from \'https://cdn.jsdelivr.net/npm/mermaid@9/dist/mermaid.esm.min.mjs\'; mermaid. Initialize({ securityLevel: \'loose\', startOnLoad: true }); let observer = new MutationObserver(mutations => { for(let mutation of mutations) { mutation.target.style.visibility = "visible"; } }); document.querySelectorAll("pre.mermaid-pre div.mermaid").forEach(item => { observer.observe(item, {  attributes: true,  attributeFilter: [\'data-processed\'] }); }); </script>'
+        template[template.index('<!-- Script: Mermaid -->')] = scriptText
 
     # style Obsidian links
     ## TODO
@@ -161,7 +168,7 @@ def main():
                                    pathTemplate=Path('_template.html'), 
                                    pathOutput=Path('../'))
             except:
-                print('**Did not convert: {}'.format(files[i]))
+                print('ERROR: Did not convert {0:-^90}'.format(str(files[i])))
             fnames.append(files[i].stem)
         else:
             print('**Did not convert: {}'.format(files[i]))

--- a/reading-notes/_build/_template.html
+++ b/reading-notes/_build/_template.html
@@ -53,6 +53,8 @@ O clemens, O pia, O dulcis Virgo Maria. -->
 	</div>
 
 <!-- Scripts -->
+<!-- Script: Latex -->
+<!-- Script: Mermaid -->
 <script src="../assets/js/jquery.min.js"></script>
 <script type="text/javascript" src="../assets/js/bigfoot.js"></script>
 <script type="text/javascript">


### PR DESCRIPTION
- add latex and mermaid support to html output
- only add on pages with metadata specifying the requirement (rather than to template for all pages) to minimize loading of javascript across the website
